### PR TITLE
Migrate build system to CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Project
 build/
+bin/
+*.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(KDK)
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,27 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Locate all KAS Source Files and Intermediates
-kas-sources := $(shell find kas -type f \( -name "*.cpp" \))
-kas-objects := $(kas-sources:%.cpp=%.o)
+cmake_minimum_required(VERSION 2.8)
 
-# Top Level Rules
-.PHONY: all
-all: build/kas
+project(KDK)
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(CMAKE_CXX_STANDARD 14)
 
-.PHONY: clean
-clean:
-	-@rm -v $(kas-objects)
-	-@rm -rf build
-	
-# Directory
-build:
-	-@mkdir -p build
+include_directories("${PROJECT_SOURCE_DIR}/kas")
 
-# Targets
-build/kas: build $(kas-objects)
-	$(CXX) -I./kas -o $@ $(kas-objects)
-
-# Intermediates
-%.o: %.cpp
-	$(CXX) -c -I./kas -std=gnu++14 -o $@ $^
+file(GLOB_RECURSE kas_sources
+	kas/*.cpp
+) 
+add_executable(kas ${kas_sources})

--- a/README.md
+++ b/README.md
@@ -48,3 +48,26 @@ declare NPC {
 }
 
 ```
+
+## Building
+In order to build the assembler, you will need to have the following tools installed on your machine:
+
+- git
+- CMake 3.0+
+- C++ Compiler that supports the C++14 Standard
+
+To build the project you will need to clone the repository to your machine. You can optionally fork the repository as well if you wish to contribute.
+
+```sh
+git clone https://github.com/tjhancocks/kestrel-development-kit.git
+cd kestrel-development-kit
+```
+
+Once you have the project cloned, then you can build the project using the following commands.
+
+```sh
+cmake -H. -Bbuild
+cmake --build build -- -j3
+```
+
+Once the project has been successfully built you will find the `kas` executable located in the `/bin` directory of the project.


### PR DESCRIPTION
The purpose of this is discussed in Issue #30, regarding adding Unit Tests to the project. Many unit test frameworks require the use of CMake and as such require that we use CMake.

This will introduce an initial `CMakeLists.txt` file to the repository and add some basic information to the README to inform users on how to build the project.