### PR TITLE
Prepare type assembler for "Assembler Directives" proposal.

### DIFF
--- a/kas/assemblers/assembler.hpp
+++ b/kas/assemblers/assembler.hpp
@@ -90,7 +90,7 @@ public:
             /**
              * Specify the symbols that can be provided as a value substitution
              */
-            kdk::assembler::field::value set_symbols(const std::vector<std::tuple<std::string, int64_t>> symbols);
+            kdk::assembler::field::value set_symbols(const std::vector<std::tuple<std::string, std::string>> symbols);
             
             /**
              * Specify a lambda that can be called so a default value can be written into the
@@ -126,12 +126,12 @@ public:
             /**
              * Returns a vector of symbol tuples for the value.
              */
-            std::vector<std::tuple<std::string, int64_t>>& symbols();
+            std::vector<std::tuple<std::string, std::string>>& symbols();
             
         private:
             std::string m_name;
             kdk::assembler::field::value::type m_type_mask;
-            std::vector<std::tuple<std::string, int64_t>> m_symbols;
+            std::vector<std::tuple<std::string, std::string>> m_symbols;
             uint64_t m_size;
             uint64_t m_offset;
             std::function<void(rsrc::data&)> m_default_value;
@@ -208,39 +208,37 @@ public:
     };
     
 public:
-    /**
-     * Construct a new assembler using the specified resource. This assembler
-     * does not specifically care about type (this information should be provided
-     * by the subclass.)
-     */
-    assembler(const kdk::resource& resource);
     
     /**
-     * Performs assembly of the resource.
+     * Performs assembly of the specified resource.
      *
      * This method should be implemented by the subclass.
      */
-    rsrc::data assemble();
+    rsrc::data assemble_resource(const kdk::resource resource);
     
     /**
-     * Assemble the specified field.
+     * Add field definition to the assembler.
      */
-    void assemble(const kdk::assembler::field field);
+    void add_field(const kdk::assembler::field field);
     
     /**
      * Find the specified field in the source resource.
      */
-    std::shared_ptr<kdk::resource::field> find_field(std::string& name, bool required = false) const;
+    std::shared_ptr<kdk::resource::field> find_field(std::string& name, const kdk::resource resource, bool required = false) const;
     
 private:
-    kdk::resource m_resource;
-    rsrc::data m_blob;
+    std::vector<kdk::assembler::field> m_fields;
+    
+    /**
+     * Assemble the specified field in to the provided resource object.
+     */
+    void assemble(const kdk::resource resource, kdk::assembler::field field, rsrc::data& blob);
     
     /**
      * Write the specified value as an integer to the data at the current
      * offset.
      */
-    void encode(const std::string value, uint64_t width, bool is_signed = true);
+    void encode(rsrc::data& blob, const std::string value, uint64_t width, bool is_signed = true);
 };
 
 };

--- a/kas/assemblers/asteroid.cpp
+++ b/kas/assemblers/asteroid.cpp
@@ -24,24 +24,25 @@
 
 // MARK: - Assembly
 
-rsrc::data kdk::asteroid::assemble()
+std::shared_ptr<kdk::assembler> kdk::asteroid_assembler()
 {
-    // Handle each of the fields in the resource.
-    assembler::assemble(
+    auto assembler = std::make_shared<kdk::assembler>();
+    
+    assembler->add_field(
         kdk::assembler::field::named("strength").set_required(true).set_values({
             kdk::assembler::field::value::expect("value", kdk::assembler::field::value::type::integer, 0, 2),
         })
     );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("spin_rate").set_values({
             kdk::assembler::field::value::expect("value", kdk::assembler::field::value::type::integer, 2, 2)
                 .set_symbols({
-                    std::make_tuple("very_slow", 10),
-                    std::make_tuple("slow", 30),
-                    std::make_tuple("medium", 50),
-                    std::make_tuple("fast", 70),
-                    std::make_tuple("very_fast", 100)
+                    std::make_tuple("very_slow", "10"),
+                    std::make_tuple("slow", "30"),
+                    std::make_tuple("medium", "50"),
+                    std::make_tuple("fast", "70"),
+                    std::make_tuple("very_fast", "100")
                 })
                 .set_default_value([] (rsrc::data& data) {
                     data.write_signed_word(50);
@@ -49,23 +50,23 @@ rsrc::data kdk::asteroid::assemble()
         })
     );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("yield").set_required(true).set_values({
             kdk::assembler::field::value::expect("type", kdk::assembler::field::value::type::resource_reference, 4, 2)
                 .set_symbols({
-                    std::make_tuple("food", 0),
-                    std::make_tuple("industrial", 1),
-                    std::make_tuple("medical", 2),
-                    std::make_tuple("luxury", 3),
-                    std::make_tuple("metal", 4),
-                    std::make_tuple("equipment", 5),
+                    std::make_tuple("food", "0"),
+                    std::make_tuple("industrial", "1"),
+                    std::make_tuple("medical", "2"),
+                    std::make_tuple("luxury", "3"),
+                    std::make_tuple("metal", "4"),
+                    std::make_tuple("equipment", "5"),
                 }),
             kdk::assembler::field::value::expect("quantity", kdk::assembler::field::value::type::integer, 6, 2)
         })
     );
     
-    assembler::assemble(
-		kdk::assembler::field::named("particles").set_required(false).set_values({
+    assembler->add_field(
+        kdk::assembler::field::named("particles").set_required(false).set_values({
             kdk::assembler::field::value::expect("count", kdk::assembler::field::value::type::integer, 8, 2)
                 .set_default_value([] (rsrc::data& data) {
                     data.write_signed_word(5);
@@ -75,53 +76,48 @@ rsrc::data kdk::asteroid::assemble()
                     data.write_long(0x00FFFFFF);
                 }),
         })
-	);
+    );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("fragments").set_required(false).set_values({
             kdk::assembler::field::value::expect("count", kdk::assembler::field::value::type::integer, 18, 2)
                 .set_default_value([] (rsrc::data& data) {
                     data.write_signed_word(2);
                 })
                 .set_symbols({
-                    std::make_tuple("none", 0)
+                    std::make_tuple("none", "0")
                 }),
             kdk::assembler::field::value::expect("fragment_1", kdk::assembler::field::value::type::resource_reference, 14, 2)
                 .set_default_value([] (rsrc::data& data) {
                     data.write_signed_word(-1);
                 })
                 .set_symbols({
-                    std::make_tuple("unused", -1)
+                    std::make_tuple("unused", "-1")
                 }),
             kdk::assembler::field::value::expect("fragment_2", kdk::assembler::field::value::type::resource_reference, 16, 2)
                 .set_default_value([] (rsrc::data& data) {
                     data.write_signed_word(-1);
                 })
                 .set_symbols({
-                    std::make_tuple("unused", -1)
+                    std::make_tuple("unused", "-1")
                 }),
         })
     );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("explosion").set_values({
             kdk::assembler::field::value::expect("value", kdk::assembler::field::value::type::integer, 20, 2)
                 .set_symbols({
-                    std::make_tuple("none", -1)
+                    std::make_tuple("none", "-1")
                 }),
         })
     );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("mass").set_values({
             kdk::assembler::field::value::expect("value", kdk::assembler::field::value::type::integer, 22, 2)
         })
     );
     
-    // Finish assembly and return the result to the caller.
-    return assembler::assemble();
+    return assembler;
 }
-
-// MARK: - Fields
-
-

--- a/kas/assemblers/asteroid.hpp
+++ b/kas/assemblers/asteroid.hpp
@@ -20,6 +20,7 @@
 * SOFTWARE.
 */
 
+#include <memory>
 #include "assemblers/assembler.hpp"
 
 #if !defined(KDK_ASTEROID)
@@ -29,19 +30,10 @@ namespace kdk
 {
 
 /**
- * The kdk::asteroid class is responsible for assembling Asteroid, or 'röid' resources.
+ * Construct a new `Asteroid` type assembler, and return it to the caller. This
+ * assembler is responsible for assembling Asteroid, or 'röid' resources.
  */
-class asteroid: public assembler
-{
-public:
-    
-    using assembler::assembler;
-
-    /**
-     * Performs assembly of the resource.
-     */
-    rsrc::data assemble();
-};
+std::shared_ptr<kdk::assembler> asteroid_assembler();
 
 };
 

--- a/kas/assemblers/sprite_animation.cpp
+++ b/kas/assemblers/sprite_animation.cpp
@@ -24,37 +24,36 @@
 
 // MARK: - Assembly
 
-rsrc::data kdk::sprite_animation::assemble()
+std::shared_ptr<kdk::assembler> kdk::sprite_animation_assembler()
 {
-    // Handle each of the fields in the resource.
-    assembler::assemble(
+    auto assembler = std::make_shared<kdk::assembler>();
+    
+    assembler->add_field(
         kdk::assembler::field::named("sprites").set_required(true).set_values({
             kdk::assembler::field::value::expect("sprite_id", kdk::assembler::field::value::type::resource_reference, 0, 2)
         })
-	);
+    );
 
-    assembler::assemble(
-		// The 'masks' field is intended to be deprecated by Kestrel and thus should be warned about.
+    assembler->add_field(
+        // The 'masks' field is intended to be deprecated by Kestrel and thus should be warned about.
         kdk::assembler::field::named("masks").set_required(false).set_deprecated(true).set_values({
             kdk::assembler::field::value::expect("mask_id", kdk::assembler::field::value::type::resource_reference, 2, 2)
         })
-	);
+    );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("size").set_required(true).set_values({
             kdk::assembler::field::value::expect("width", kdk::assembler::field::value::type::integer, 4, 2),
             kdk::assembler::field::value::expect("height", kdk::assembler::field::value::type::integer, 6, 2),
         })
-	);
+    );
     
-    assembler::assemble(
+    assembler->add_field(
         kdk::assembler::field::named("tiles").set_required(true).set_values({
             kdk::assembler::field::value::expect("x_count", kdk::assembler::field::value::type::integer, 8, 2),
             kdk::assembler::field::value::expect("y_count", kdk::assembler::field::value::type::integer, 10, 2),
         })
     );
     
-    
-    // Finish assembly and return the result to the caller.
-    return assembler::assemble();
+    return assembler;
 }

--- a/kas/assemblers/sprite_animation.hpp
+++ b/kas/assemblers/sprite_animation.hpp
@@ -20,6 +20,7 @@
 * SOFTWARE.
 */
 
+#include <memory>
 #include "assemblers/assembler.hpp"
 
 #if !defined(KDK_SPRITE_ANIMATION)
@@ -29,22 +30,10 @@ namespace kdk
 {
 
 /**
- * The kdk::assembler class houses the core implementation for converting a
- * kdk::resource into a rsrc::data object. The class itself should be subclassed
- * in order to set up the appropriate layout and definition for the resource
- * type.
- */
-class sprite_animation: public assembler
-{
-public:
-    
-    using assembler::assembler;
-
-    /**
-     * Performs assembly of the resource.
-     */
-    rsrc::data assemble();
-};
+* Construct a new `SpriteAnimation` type assembler, and return it to the caller. This
+* assembler is responsible for assembling SpriteAnimation, or 'spïn' resources.
+*/
+std::shared_ptr<kdk::assembler> sprite_animation_assembler();
 
 };
 

--- a/kas/structures/target.cpp
+++ b/kas/structures/target.cpp
@@ -54,12 +54,12 @@ void kdk::target::build()
         auto type = resource.type();
         
         if (type == "SpriteAnimation") {
-            kdk::sprite_animation assembler { resource };
-            rf->add_resource("spïn", resource.id(), resource.name(), assembler.assemble());
+            auto assembler = kdk::sprite_animation_assembler();
+            rf->add_resource("spïn", resource.id(), resource.name(), assembler->assemble_resource(resource));
         }
         else if (type == "Asteroid") {
-            kdk::asteroid assembler { resource };
-            rf->add_resource("röid", resource.id(), resource.name(), assembler.assemble());
+            auto assembler = kdk::asteroid_assembler();
+            rf->add_resource("röid", resource.id(), resource.name(), assembler->assemble_resource(resource));
         }
     }
     


### PR DESCRIPTION
This change is intended to allow and make it easier to implement part of the "Assembler Directives" (#33) proposal, which would allow defining resource types and assemblers in KDL itself.

This changes adjusts how `kdk::assembler` instances are created and handled. It no longer requires a subclass, and each assembler can be reused many times. A further bit of work might be to add a "pool" of named assemblers so they can be added to the pool after creation and then called upon when required.