### PR TITLE
Add support for rez format

### DIFF
--- a/kas/rsrc/file.cpp
+++ b/kas/rsrc/file.cpp
@@ -154,6 +154,10 @@ void rsrc::file::write()
             fork_data = write_extended();
             break;
         }
+        case file::format::rez: {
+            fork_data = write_rez();
+            break;
+        }
     }
     
     fork_data.save(m_path);
@@ -352,6 +356,102 @@ rsrc::data rsrc::file::write_standard()
     fork_data.write_long(map_offset);
     fork_data.write_long(data_length);
     fork_data.write_long(map_length);
+    
+    return fork_data;
+}
+
+rsrc::data rsrc::file::write_rez()
+{
+    rsrc::data fork_data = data(data::endian::little);
+    
+    const std::string rez_signature = "BRGR";
+    const std::string map_name = "resource.map";
+    const uint32_t rez_version = 1;
+    const uint32_t resource_offset_length = 12;
+    const uint32_t map_header_length = 8;
+    const uint32_t type_info_length = 12;
+    const uint32_t resource_info_length = 266;
+    
+    // Count up the total number of resources
+    uint32_t resource_count = 0;
+    for (auto container : m_containers) {
+        resource_count += container->resources().size();
+    }
+    
+    // The resource map itself is considered an entry for the offsets in the header
+    uint32_t entry_count = resource_count + 1;
+    
+    // Calculate header length - this is from the end of the preamble to the start of the resource data
+    uint32_t header_length = 12 + (entry_count * resource_offset_length) + map_name.size()+1;
+    
+    // Write the preamble
+    fork_data.write_cstr(rez_signature, 4);
+    fork_data.write_long(rez_version);
+    fork_data.write_long(header_length);
+    
+    // Calculate the offset to the first resource data
+    uint32_t resource_offset = fork_data.size() + header_length;
+    
+    // Write the header
+    uint32_t index = 1; // Index of first resource, starting at 1
+    fork_data.write_long(1); // Unknown value
+    fork_data.write_long(index);
+    fork_data.write_long(entry_count);
+    for (auto container : m_containers) {
+        for (auto resource : container->resources()) {
+            // Get the data for the resource and determine its size.
+            auto data = resource->blob();
+            auto size = data.size();
+            fork_data.write_long(resource_offset);
+            fork_data.write_long(static_cast<uint32_t>(size));
+            fork_data.write_long(0); // Unknown value
+            resource_offset += size;
+        }
+    }
+    
+    uint32_t type_count = m_containers.size();
+    // Calculate offset within map to start of resource info
+    uint32_t type_offset = map_header_length + (type_count * type_info_length);
+    uint32_t map_length = type_offset + (resource_count * resource_info_length);
+    // Write the offset and size of the resource map
+    fork_data.write_long(resource_offset);
+    fork_data.write_long(map_length);
+    fork_data.write_long(12 + (entry_count * resource_offset_length)); // Unknown value
+
+    // Write the name of the resource map
+    fork_data.write_cstr(map_name);
+    
+    // Write each resource
+    for (auto container : m_containers) {
+        for (auto resource : container->resources()) {
+            fork_data.write_data(resource->blob());
+        }
+    }
+    
+    // Write the resource map as big endian
+    // Map header
+    fork_data.set_endian(data::endian::big);
+    fork_data.write_long(8); // Unknown value
+    fork_data.write_long(type_count);
+    
+    // Type counts and offsets
+    for (auto container : m_containers) {
+        auto count = container->resources().size();
+        fork_data.write_cstr(container->type_code(), 4);
+        fork_data.write_long(type_offset);
+        fork_data.write_long(count);
+        type_offset += resource_info_length * count;
+    }
+    
+    // Info for each resource
+    for (auto container : m_containers) {
+        for (auto resource : container->resources()) {
+            fork_data.write_long(index++);
+            fork_data.write_cstr(container->type_code(), 4);
+            fork_data.write_signed_word(static_cast<int16_t>(resource->id()));
+            fork_data.write_cstr(resource->name(), 256);
+        }
+    }
     
     return fork_data;
 }

--- a/kas/rsrc/file.hpp
+++ b/kas/rsrc/file.hpp
@@ -48,7 +48,8 @@ public:
     enum format
     {
         standard,
-        extended
+        extended,
+        rez
     };
     
     /**
@@ -185,6 +186,7 @@ private:
     
     rsrc::data write_extended();
     rsrc::data write_standard();
+    rsrc::data write_rez();
 };
 
 };


### PR DESCRIPTION
This PR adds support for the Win Nova .rez format. Not sure if there's really much point to this, but here we are :)
Note I haven't added any switches to choose the format, it still defaults to standard resource fork.

@tjhancocks the spec I'm working off is based on code from Mission Computer and includes a few unknown values. Let me know if you have any knowledge of any of them.