### PR TITLE
Implement the @import directive in KDL.

### DIFF
--- a/examples/kdl/hello.kdl
+++ b/examples/kdl/hello.kdl
@@ -1,0 +1,3 @@
+` This is part of the 'import-test.kdl' file.
+
+@out { "Hello, World!" }

--- a/examples/kdl/import-test.kdl
+++ b/examples/kdl/import-test.kdl
@@ -1,0 +1,5 @@
+` This is a test of the import directive.
+
+@import { "hello.kdl" }
+
+@out { "If 'Hello World' was shown, then the test was successful!" }

--- a/kas/kdl/sema.cpp
+++ b/kas/kdl/sema.cpp
@@ -65,6 +65,11 @@ void kdl::sema::run()
 
 // MARK: - Stream
 
+void kdl::sema::insert_tokens(std::vector<kdl::lexer::token> tokens)
+{
+    m_tokens.insert(m_tokens.begin() + m_ptr, tokens.begin(), tokens.end());
+}
+
 bool kdl::sema::finished(long offset, long count) const
 {
     auto ptr = (m_ptr + offset);

--- a/kas/kdl/sema.hpp
+++ b/kas/kdl/sema.hpp
@@ -123,6 +123,11 @@ public:
      */
     kdk::target& target();
     
+    /**
+     * Insert new tokens into the token stream at the current location.
+     */
+    void insert_tokens(std::vector<kdl::lexer::token> tokens);
+    
 private:
     long m_ptr { 0 };
     std::vector<kdl::lexer::token> m_tokens;

--- a/kas/kdl/sema/directive.cpp
+++ b/kas/kdl/sema/directive.cpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include "kdl/sema/directive.hpp"
 #include "diagnostic/log.hpp"
+#include "kdl/lexer.hpp"
 
 // MARK: - Parser
 
@@ -64,6 +65,13 @@ void kdl::directive::parse(kdl::sema *sema)
     if (directive == "out") {
         for (auto a : args) {
             std::cout << a.text() << std::endl;
+        }
+    }
+    else if (directive == "import") {
+        for (auto a : args) {
+            auto lexer = kdl::lexer::open_file(a.text());
+            auto tokens = lexer.analyze();
+            sema->insert_tokens(tokens);
         }
     }
 }


### PR DESCRIPTION
This directive allows the assembler to open, perform lexical analysis and inject the resulting tokens into the current token stream immediately following the @import directive.